### PR TITLE
Allow workflow and activities to be defined without interface

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -8,8 +8,6 @@
     <projectFiles>
         <directory name="src" />
         <ignoreFiles>
-            <file name="src/WorkerFactory.php" />
-            <file name="src/InvokeActivityRouter.php" />
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>

--- a/src/DeclarationLocator.php
+++ b/src/DeclarationLocator.php
@@ -24,10 +24,10 @@ final class DeclarationLocator implements DeclarationLocatorInterface
                 continue;
             }
 
-            foreach ($class->getInterfaces() as $interface) {
-                if ($this->reader->firstClassMetadata($interface, WorkflowInterface::class)) {
+            foreach (array_merge($class->getInterfaces(), [$class]) as $type) {
+                if ($this->reader->firstClassMetadata($type, WorkflowInterface::class)) {
                     yield WorkflowInterface::class => $class;
-                } else if ($this->reader->firstClassMetadata($interface, ActivityInterface::class)) {
+                } else if ($this->reader->firstClassMetadata($type, ActivityInterface::class)) {
                     yield ActivityInterface::class => $class;
                 }
             }

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -30,7 +30,7 @@ final class Dispatcher implements DispatcherInterface
     public function serve(): void
     {
         // finds all available workflows, activity types and commands in a given directory
-        /** @var array<class-string<WorkflowInterface|ActivityInterface>, ReflectionClass> $declarations */
+        /** @var array<class-string<WorkflowInterface>|class-string<ActivityInterface>, ReflectionClass> $declarations */
         $declarations = $this->container->get(DeclarationLocatorInterface::class)->getDeclarations();
 
         // factory initiates and runs task queue specific activity and workflow workers


### PR DESCRIPTION
Now every workflow and activity is required to have an interface. However, this is optional and `php-sdk` can work directly with classes. I think for simple cases the interface is optional and the `DeclarationLocator` can find not only interfaces, but classes too.

P.S.: i couldn't find a test for `DeclarationLocator`, so I didn't add a test for this case. If necessary, I could write a test on the `DeclarationLocator`.