### PR TITLE
Add ability to configure task queue

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -8,8 +8,6 @@
     <projectFiles>
         <directory name="src" />
         <ignoreFiles>
-            <file name="src/WorkerFactory.php" />
-            <file name="src/InvokeActivityRouter.php" />
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -30,7 +30,7 @@ final class Dispatcher implements DispatcherInterface
     public function serve(): void
     {
         // finds all available workflows, activity types and commands in a given directory
-        /** @var array<class-string<WorkflowInterface|ActivityInterface>, ReflectionClass> $declarations */
+        /** @var array<class-string<WorkflowInterface>|class-string<ActivityInterface>, ReflectionClass> $declarations */
         $declarations = $this->container->get(DeclarationLocatorInterface::class)->getDeclarations();
 
         // factory initiates and runs task queue specific activity and workflow workers

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -9,7 +9,7 @@ use Spiral\Boot\DispatcherInterface;
 use Spiral\Boot\FinalizerInterface;
 use Spiral\Core\Container;
 use Spiral\RoadRunner\Environment\Mode;
-use Spiral\RoadRunner\EnvironmentInterface;
+use Spiral\Boot\EnvironmentInterface;
 use Temporal\Activity\ActivityInterface;
 use Temporal\Worker\WorkerFactoryInterface;
 use Temporal\Workflow\WorkflowInterface;
@@ -24,7 +24,7 @@ final class Dispatcher implements DispatcherInterface
 
     public function canServe(): bool
     {
-        return \PHP_SAPI === 'cli' && $this->env->getMode() === Mode::MODE_TEMPORAL;
+        return \PHP_SAPI === 'cli' && $this->env->get('RR_MODE', '') === Mode::MODE_TEMPORAL;
     }
 
     public function serve(): void
@@ -37,7 +37,7 @@ final class Dispatcher implements DispatcherInterface
         $factory = $this->container->get(WorkerFactoryInterface::class);
 
         // Worker that listens on a task queue and hosts both workflow and activity implementations.
-        $worker = $factory->newWorker();
+        $worker = $factory->newWorker((string)$this->env->get('TEMPORAL_TASK_QUEUE', WorkerFactoryInterface::DEFAULT_TASK_QUEUE));
 
         $finalizer = $this->container->get(FinalizerInterface::class);
         $worker->registerActivityFinalizer(fn() => $finalizer->finalize());


### PR DESCRIPTION
Added the ability to pass the name of the queue, so that workflow and activity can be run on different queues.

I'm not sure about using `Spiral\Boot\EnvironmentInterface`, but then I should use two different `EnvironmentInterface` with aliases. 