### PR TITLE
Adding an ability to register activities and workflows in specific workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 
 Make sure that your server is configured with following PHP version and extensions:
 
-- PHP 8.0+
-- Spiral framework 2.9+
+- PHP 8.1+
+- Spiral framework 3.0+
 
 ## Installation
 
@@ -33,6 +33,28 @@ protected const LOAD = [
 
 > Note: if you are using [`spiral-packages/discoverer`](https://github.com/spiral-packages/discoverer),
 > you don't need to register bootloader by yourself.
+
+#### Configuration
+
+The package is already configured by default, use these features only if you need to change the default configuration.
+The package provides the ability to configure `address`, `namespace`, `defaultWorker`, `workers` parameters.
+Create file `app/config/temporal.php` and configure options. For example:
+
+```php
+declare(strict_types=1);
+
+use Temporal\Worker\WorkerFactoryInterface;
+use Temporal\Worker\WorkerOptions;
+
+return [
+    'address' => env('TEMPORAL_ADDRESS', 'localhost:7233'), 
+    'namespace' => 'App\\Workflow',
+    'defaultWorker' => WorkerFactoryInterface::DEFAULT_TASK_QUEUE,
+    'workers' => [
+        'workerName' => WorkerOptions::new()
+    ],
+];
+```
 
 #### RoadRunner configuration
 
@@ -347,6 +369,37 @@ class PingController
             $request->name
         );
     }
+}
+```
+
+## Running workers with different task queue
+
+Add a `Spiral\TemporalBridge\Attribute\AssignWorker` attribute to your Workflow or Activity with the `name` of the worker.
+This Workflow or Activity will be processed by the specified worker.
+Example:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Workflow;
+
+use Spiral\TemporalBridge\Attribute\AssignWorker;
+use Temporal\Workflow\WorkflowInterface;
+
+#[AssignWorker(name: 'worker1')]
+#[WorkflowInterface]
+interface MoneyTransferWorkflowInterface
+{
+    #[WorkflowMethod]
+    public function ping(...): \Generator;
+    
+    #[SignalMethod]
+    function withdraw(): void;
+    
+    #[SignalMethod]
+    function deposit(): void;
 }
 ```
 

--- a/src/Attribute/AssignWorker.php
+++ b/src/Attribute/AssignWorker.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\TemporalBridge\Attribute;
+
+use Spiral\Attributes\NamedArgumentConstructor;
+
+#[\Attribute(\Attribute::TARGET_CLASS), NamedArgumentConstructor]
+final class AssignWorker
+{
+    public function __construct(
+        public string $name
+    ) {
+    }
+}

--- a/src/Config/TemporalConfig.php
+++ b/src/Config/TemporalConfig.php
@@ -5,13 +5,17 @@ declare(strict_types=1);
 namespace Spiral\TemporalBridge\Config;
 
 use Spiral\Core\InjectableConfig;
+use Temporal\Worker\WorkerFactoryInterface;
+use Temporal\Worker\WorkerOptions;
 
 final class TemporalConfig extends InjectableConfig
 {
     public const CONFIG = 'temporal';
     protected array $config = [
         'address' => null,
-        'namespace' => null
+        'namespace' => null,
+        'defaultWorker' => WorkerFactoryInterface::DEFAULT_TASK_QUEUE,
+        'workers' => [],
     ];
 
     public function getDefaultNamespace(): string
@@ -22,5 +26,16 @@ final class TemporalConfig extends InjectableConfig
     public function getAddress(): string
     {
         return $this->config['address'] ?? 'localhost:7233';
+    }
+
+    public function getDefaultWorker(): string
+    {
+        return $this->config['defaultWorker'] ?? WorkerFactoryInterface::DEFAULT_TASK_QUEUE;
+    }
+
+    /** @psalm-return array<non-empty-string, WorkerOptions> */
+    public function getWorkers(): array
+    {
+        return $this->config['workers'] ?? [];
     }
 }

--- a/src/WorkersRegistry.php
+++ b/src/WorkersRegistry.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\TemporalBridge;
+
+use Spiral\Attributes\ReaderInterface;
+use Spiral\Boot\FinalizerInterface;
+use Spiral\TemporalBridge\Attribute\AssignWorker;
+use Spiral\TemporalBridge\Config\TemporalConfig;
+use Temporal\Worker\WorkerFactoryInterface;
+use Temporal\Worker\WorkerInterface;
+use Temporal\Worker\WorkerOptions;
+
+final class WorkersRegistry implements WorkersRegistryInterface
+{
+    /** @psalm-var array<non-empty-string, WorkerInterface> */
+    private array $workers = [];
+
+    /** @psalm-param array<non-empty-string, WorkerOptions> $options */
+    public function __construct(
+        private WorkerFactoryInterface $workerFactory,
+        private ReaderInterface $reader,
+        private FinalizerInterface $finalizer,
+        private TemporalConfig $config
+    ) {
+    }
+
+    public function get(\ReflectionClass $declaration): WorkerInterface
+    {
+        $name = $this->resolveName($declaration);
+        $options = $this->config->getWorkers();
+
+        if (!$this->hasWorker($name)) {
+            $this->workers[$name] = $this->workerFactory->newWorker($name, $options[$name] ?? null);
+            $this->workers[$name]->registerActivityFinalizer(fn() => $this->finalizer->finalize());
+        }
+
+        return $this->workers[$name];
+    }
+
+    private function hasWorker(string $name): bool
+    {
+        return isset($this->workers[$name]);
+    }
+
+    private function resolveName(\ReflectionClass $declaration): string
+    {
+        $assignWorker = $this->reader->firstClassMetadata($declaration, AssignWorker::class);
+
+        if ($assignWorker === null) {
+            return $this->config->getDefaultWorker();
+        }
+
+        return $assignWorker->name;
+    }
+}

--- a/src/WorkersRegistryInterface.php
+++ b/src/WorkersRegistryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\TemporalBridge;
+
+use Temporal\Worker\WorkerInterface;
+
+interface WorkersRegistryInterface
+{
+    public function get(\ReflectionClass $declaration): WorkerInterface;
+}

--- a/tests/app/src/SomeActivity.php
+++ b/tests/app/src/SomeActivity.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\TemporalBridge\Tests\App;
+
+use Spiral\TemporalBridge\Attribute\AssignWorker;
+
+#[AssignWorker(name: 'worker1')]
+class SomeActivity
+{
+}

--- a/tests/app/src/SomeWorkflow.php
+++ b/tests/app/src/SomeWorkflow.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\TemporalBridge\Tests\App;
+
+use Spiral\TemporalBridge\Attribute\AssignWorker;
+
+#[AssignWorker(name: 'worker2')]
+class SomeWorkflow
+{
+}

--- a/tests/app/src/WithoutAttribute.php
+++ b/tests/app/src/WithoutAttribute.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\TemporalBridge\Tests\App;
+
+class WithoutAttribute
+{
+}

--- a/tests/src/Attribute/AssignWorkerTest.php
+++ b/tests/src/Attribute/AssignWorkerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\TemporalBridge\Tests\Attribute;
+
+use Spiral\Attributes\Factory;
+use Spiral\TemporalBridge\Attribute\AssignWorker;
+use Spiral\TemporalBridge\Tests\App\SomeActivity;
+use Spiral\TemporalBridge\Tests\App\SomeWorkflow;
+use Spiral\TemporalBridge\Tests\App\WithoutAttribute;
+use Spiral\TemporalBridge\Tests\TestCase;
+
+final class AssignWorkerTest extends TestCase
+{
+    /** @dataProvider assignWorkerDataProvider */
+    public function testAssignWorkerAttribute(\ReflectionClass $class, ?AssignWorker $expected = null): void
+    {
+        $reader = (new Factory())->create();
+
+        $this->assertEquals($expected, $reader->firstClassMetadata($class, AssignWorker::class));
+    }
+
+    public function assignWorkerDataProvider(): \Traversable
+    {
+        yield [new \ReflectionClass(SomeActivity::class), new AssignWorker('worker1')];
+        yield [new \ReflectionClass(SomeWorkflow::class), new AssignWorker('worker2')];
+        yield [new \ReflectionClass(WithoutAttribute::class), null];
+    }
+}

--- a/tests/src/Bootloader/TemporalBridgeBootloaderTest.php
+++ b/tests/src/Bootloader/TemporalBridgeBootloaderTest.php
@@ -5,11 +5,15 @@ declare(strict_types=1);
 namespace Spiral\TemporalBridge\Tests\Bootloader;
 
 use Spiral\Attributes\ReaderInterface;
+use Spiral\TemporalBridge\Bootloader\TemporalBridgeBootloader;
+use Spiral\TemporalBridge\Config\TemporalConfig;
 use Spiral\TemporalBridge\DeclarationLocator;
 use Spiral\TemporalBridge\DeclarationLocatorInterface;
 use Spiral\TemporalBridge\Preset\PresetRegistry;
 use Spiral\TemporalBridge\Preset\PresetRegistryInterface;
 use Spiral\TemporalBridge\Tests\TestCase;
+use Spiral\TemporalBridge\WorkersRegistry;
+use Spiral\TemporalBridge\WorkersRegistryInterface;
 use Spiral\TemporalBridge\Workflow\WorkflowManager;
 use Spiral\TemporalBridge\WorkflowManagerInterface;
 use Spiral\TemporalBridge\WorkflowPresetLocator;
@@ -17,6 +21,7 @@ use Spiral\TemporalBridge\WorkflowPresetLocatorInterface;
 use Temporal\Client\WorkflowClient;
 use Temporal\Client\WorkflowClientInterface;
 use Temporal\Worker\WorkerFactoryInterface;
+use Temporal\Worker\WorkerOptions;
 use Temporal\WorkerFactory;
 
 class TemporalBridgeBootloaderTest extends TestCase
@@ -68,6 +73,27 @@ class TemporalBridgeBootloaderTest extends TestCase
         $this->assertContainerBoundAsSingleton(
             PresetRegistryInterface::class,
             PresetRegistry::class
+        );
+    }
+
+    public function testWorkersRegistry(): void
+    {
+        $this->assertContainerBoundAsSingleton(
+            WorkersRegistryInterface::class,
+            WorkersRegistry::class
+        );
+    }
+
+    public function testAddWorkerOptions(): void
+    {
+        $bootloader = $this->getContainer()->get(TemporalBridgeBootloader::class);
+
+        $bootloader->addWorkerOptions('first', WorkerOptions::new());
+        $bootloader->addWorkerOptions('second', WorkerOptions::new());
+
+        $this->assertEquals(
+            ['first' => WorkerOptions::new(), 'second' => WorkerOptions::new()],
+            $this->getConfig(TemporalConfig::CONFIG)['workers']
         );
     }
 }

--- a/tests/src/Config/TemporalConfigTest.php
+++ b/tests/src/Config/TemporalConfigTest.php
@@ -6,6 +6,8 @@ namespace Spiral\TemporalBridge\Tests\Config;
 
 use Spiral\TemporalBridge\Config\TemporalConfig;
 use Spiral\TemporalBridge\Tests\TestCase;
+use Temporal\Worker\WorkerFactoryInterface;
+use Temporal\Worker\WorkerOptions;
 
 final class TemporalConfigTest extends TestCase
 {
@@ -41,4 +43,40 @@ final class TemporalConfigTest extends TestCase
         $this->assertSame('localhost:7233', $config->getAddress());
     }
 
+    public function testGetsDefaultWorker(): void
+    {
+        $config = new TemporalConfig([
+            'defaultWorker' => 'some-worker'
+        ]);
+
+        $this->assertSame('some-worker', $config->getDefaultWorker());
+    }
+
+    public function testGetsDefaultWorkerIfItNotSet(): void
+    {
+        $config = new TemporalConfig([]);
+
+        $this->assertSame(WorkerFactoryInterface::DEFAULT_TASK_QUEUE, $config->getDefaultWorker());
+    }
+
+    public function testGetsWorkers(): void
+    {
+        $workers = [
+            'first' => WorkerOptions::new(),
+            'second' => WorkerOptions::new()
+        ];
+
+        $config = new TemporalConfig([
+            'workers' => $workers
+        ]);
+
+        $this->assertSame($workers, $config->getWorkers());
+    }
+
+    public function testGetsWorkersIfItNotSet(): void
+    {
+        $config = new TemporalConfig([]);
+
+        $this->assertSame([], $config->getWorkers());
+    }
 }

--- a/tests/src/WorkersRegistryTest.php
+++ b/tests/src/WorkersRegistryTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\TemporalBridge\Tests\Preset;
+
+use Spiral\Attributes\AttributeReader;
+use Spiral\Boot\FinalizerInterface;
+use Spiral\TemporalBridge\Config\TemporalConfig;
+use Spiral\TemporalBridge\Tests\App\SomeActivity;
+use Spiral\TemporalBridge\Tests\App\SomeWorkflow;
+use Spiral\TemporalBridge\Tests\App\WithoutAttribute;
+use Spiral\TemporalBridge\Tests\TestCase;
+use Spiral\TemporalBridge\WorkersRegistry;
+use Temporal\DataConverter\DataConverterInterface;
+use Temporal\Worker\Transport\RPCConnectionInterface;
+use Temporal\Worker\WorkerFactoryInterface;
+use Temporal\Worker\WorkerInterface;
+use Temporal\Worker\WorkerOptions;
+use Temporal\WorkerFactory;
+
+final class WorkersRegistryTest extends TestCase
+{
+    public function testGetWorker(): void
+    {
+        $options = WorkerOptions::new();
+        $options->enableSessionWorker = true;
+        $factory =  new WorkerFactory(
+            $this->createMock(DataConverterInterface::class),
+            $this->createMock(RPCConnectionInterface::class)
+        );
+
+        $registry = new WorkersRegistry(
+            $factory,
+            new AttributeReader(),
+            $this->createMock(FinalizerInterface::class),
+            new TemporalConfig(['workers' => ['worker1' => $options]])
+        );
+
+        $worker = $registry->get(new \ReflectionClass(SomeActivity::class));
+        $this->assertInstanceOf(WorkerInterface::class, $worker);
+        $this->assertTrue($worker->getOptions()->enableSessionWorker);
+
+        $worker = $registry->get(new \ReflectionClass(SomeWorkflow::class));
+        $this->assertInstanceOf(WorkerInterface::class, $worker);
+        $this->assertFalse($worker->getOptions()->enableSessionWorker);
+    }
+
+    public function testHasWorker(): void
+    {
+        $registry = new WorkersRegistry(
+            $this->createMock(WorkerFactoryInterface::class),
+            new AttributeReader(),
+            $this->createMock(FinalizerInterface::class),
+            new TemporalConfig()
+        );
+        $method = new \ReflectionMethod($registry, 'hasWorker');
+
+        $this->assertFalse($method->invoke($registry, 'default'));
+
+        $registry->get(new \ReflectionClass(WithoutAttribute::class));
+        $this->assertTrue($method->invoke($registry, 'default'));
+    }
+
+    /** @dataProvider resolveNameDataProvider */
+    public function testResolveName(\ReflectionClass $class, string $expectedName): void
+    {
+        $registry = new WorkersRegistry(
+            $this->createMock(WorkerFactoryInterface::class),
+            new AttributeReader(),
+            $this->createMock(FinalizerInterface::class),
+            new TemporalConfig()
+        );
+        $method = new \ReflectionMethod($registry, 'resolveName');
+
+        $this->assertSame($expectedName, $method->invoke($registry, $class));
+    }
+
+    public function resolveNameDataProvider(): \Traversable
+    {
+        yield [new \ReflectionClass(SomeActivity::class), 'worker1'];
+        yield [new \ReflectionClass(SomeWorkflow::class), 'worker2'];
+        yield [new \ReflectionClass(WithoutAttribute::class), WorkerFactoryInterface::DEFAULT_TASK_QUEUE];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ✔️

- Added an ability to register activities and workflows in specific workers.
Need to add `Spiral\TemporalBridge\Attribute\AssignWorker` with a worker name.
```php
use Spiral\TemporalBridge\Attribute\AssignWorker;

#[AssignWorker(name: 'worker1')]
class SomeActivity
{
}
```
- Added `defaultWorker` parameter in config. In this parameter, can specify the name of the default worker.
- Added  `workers` parameter in config. In this parameter, can set worker options.
```php
// file app/config/temporal.php

use Temporal\Worker\WorkerOptions;

return [
    'workers' => [
        'worker1' => WorkerOptions::new()
    ]
]
```
- Added method `addWorkerOptions` to the `Spiral\TemporalBridge\Bootloader\TemporalBridgeBootloader`. This method allows to register workers with the necessary options.
```php
<?php

declare(strict_types=1);

namespace App\Bootloader;

use Spiral\Boot\Bootloader\Bootloader;
use Spiral\TemporalBridge\Bootloader\TemporalBridgeBootloader;
use Temporal\Worker\WorkerOptions;

final class AppBootloader extends Bootloader
{
    public function init(TemporalBridgeBootloader $temporalBridgeBootloader): void 
    {
        $temporalBridgeBootloader->addWorkerOptions('first', WorkerOptions::new());
        $temporalBridgeBootloader->addWorkerOptions('second', WorkerOptions::new());
    }
}
```

