### PR TITLE
Allow user to extend initialization

### DIFF
--- a/src/Bootloader/TemporalBridgeBootloader.php
+++ b/src/Bootloader/TemporalBridgeBootloader.php
@@ -81,7 +81,7 @@ class TemporalBridgeBootloader extends Bootloader
         $this->config->modify(TemporalConfig::CONFIG, new Append('workers', $worker, $options));
     }
 
-    private function initWorkflowPresetLocator(
+    protected function initWorkflowPresetLocator(
         FactoryInterface $factory,
         ClassesInterface $classes
     ): WorkflowPresetLocatorInterface {
@@ -92,7 +92,7 @@ class TemporalBridgeBootloader extends Bootloader
         );
     }
 
-    private function initConfig(EnvironmentInterface $env): void
+    protected function initConfig(EnvironmentInterface $env): void
     {
         $this->config->setDefaults(
             TemporalConfig::CONFIG,
@@ -105,7 +105,7 @@ class TemporalBridgeBootloader extends Bootloader
         );
     }
 
-    private function initWorkflowClient(TemporalConfig $config): WorkflowClientInterface
+    protected function initWorkflowClient(TemporalConfig $config): WorkflowClientInterface
     {
         return WorkflowClient::create(
             ServiceClient::create($config->getAddress()),
@@ -113,7 +113,7 @@ class TemporalBridgeBootloader extends Bootloader
         );
     }
 
-    private function initWorkerFactory(): WorkerFactoryInterface
+    protected function initWorkerFactory(): WorkerFactoryInterface
     {
         return new WorkerFactory(
             DataConverter::createDefault(),
@@ -121,7 +121,7 @@ class TemporalBridgeBootloader extends Bootloader
         );
     }
 
-    private function initDeclarationLocator(ClassesInterface $classes): DeclarationLocatorInterface
+    protected function initDeclarationLocator(ClassesInterface $classes): DeclarationLocatorInterface
     {
         return new \Spiral\TemporalBridge\DeclarationLocator(
             $classes,
@@ -129,7 +129,7 @@ class TemporalBridgeBootloader extends Bootloader
         );
     }
 
-    private function initWorkersRegistry(
+    protected function initWorkersRegistry(
         WorkerFactoryInterface $workerFactory,
         FinalizerInterface $finalizer,
         TemporalConfig $config


### PR DESCRIPTION
This PR allows user to override initialization methods in `TemporalBridgeBootloader` bootloader. For example, it can be useful for extending temporal sdk data converters.

Usage example: 

### First step

> Note: In samples I use PHP 8.1

Create a `SymfonyConverter` class with following contents:

```php
<?php

declare(strict_types=1);

namespace Library\TemporalSdkObjectConverter;

use Symfony\Component\Serializer\Encoder\JsonDecode;
use Symfony\Component\Serializer\Encoder\JsonEncode;
use Symfony\Component\Serializer\Exception\ExceptionInterface;
use Symfony\Component\Serializer\Normalizer\BackedEnumNormalizer;
use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
use Symfony\Component\Serializer\Serializer;
use Symfony\Component\Serializer\SerializerInterface;
use Temporal\Api\Common\V1\Payload;
use Temporal\DataConverter\Converter;
use Temporal\DataConverter\Type;
use Temporal\Exception\DataConverterException;

class SymfonyConverter extends Converter
{
    public function __construct(
        private readonly SerializerInterface $serializer = new Serializer(normalizers: [
            new BackedEnumNormalizer(),
            new ObjectNormalizer(),
        ], encoders: [
            new JsonEncode(),
            new JsonDecode()
        ])
    ) {}

    public function getEncodingType(): string
    {
        return 'json/object';
    }

    public function toPayload(mixed $value): ?Payload
    {
        if (!\is_object($value)) {
            return null;
        }

        return $this->create(
            $this->serializer->serialize($value, 'json')
        );
    }

    public function fromPayload(Payload $payload, Type $type): object
    {
        if (!$type->isClass()) {
            throw new DataConverterException('Unable to decode value using object converter.');
        }

        try {
            return $this->serializer->deserialize($payload->getData(), $type->getName(), 'json');
        } catch (ExceptionInterface $e) {
            throw new DataConverterException($e->getMessage(), $e->getCode(), $e);
        }
    }
}
```

### Second step

To register a custom `DataConverter` within Spiral framework you can extend from `TemporalBridgeBootloader` bootloader and override `initWorkerFactory` method:

```php
use Spiral\TemporalBridge\Bootloader\CustomTemporalDataConverter;
use Temporal\DataConverter\BinaryConverter;
use Temporal\DataConverter\DataConverter;
use Temporal\DataConverter\JsonConverter;
use Temporal\DataConverter\NullConverter;
use Temporal\DataConverter\ProtoJsonConverter;
use Library\TemporalSdkObjectConverter\SymfonyConverter;

class CustomTemporalDataConverter extends TemporalBridgeBootloader 
{
      protected function initWorkerFactory(): WorkerFactoryInterface
      {
          return new WorkerFactory(
              new DataConverter(
                  new NullConverter(),
                  new BinaryConverter(),
                  new ProtoJsonConverter(),
                  new SymfonyConverter(),
                  new JsonConverter(),
              ),
              Goridge::create()
        );
      }
}
```

We added here a `SymfonyConverter` which do (de-)serialize PHP objects.

P.S.  Don't forget register the bootloader.

Now you can pass PHP objects arguments to activity/workflow methods.
