### PR TITLE
Adds the ability to get typed workflow object from running workflow

### DIFF
--- a/src/Exception/WorkflowNotFoundException.php
+++ b/src/Exception/WorkflowNotFoundException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\TemporalBridge\Exception;
+
+class WorkflowNotFoundException extends TemporalBridgeException
+{
+
+}

--- a/src/Generator/ActivityGenerator.php
+++ b/src/Generator/ActivityGenerator.php
@@ -8,6 +8,9 @@ use Nette\PhpGenerator\ClassType;
 use Nette\PhpGenerator\PhpNamespace;
 use Psr\Log\LoggerInterface;
 
+/**
+ * @internal
+ */
 final class ActivityGenerator implements FileGeneratorInterface
 {
     public function generate(Context $context, PhpNamespace $namespace): PhpCodePrinter

--- a/src/Generator/ActivityInterfaceGenerator.php
+++ b/src/Generator/ActivityInterfaceGenerator.php
@@ -9,6 +9,9 @@ use Nette\PhpGenerator\PhpNamespace;
 use Temporal\Activity\ActivityInterface;
 use Temporal\Activity\ActivityMethod;
 
+/**
+ * @internal
+ */
 final class ActivityInterfaceGenerator implements FileGeneratorInterface
 {
     public function generate(Context $context, PhpNamespace $namespace): PhpCodePrinter

--- a/src/Generator/Context.php
+++ b/src/Generator/Context.php
@@ -7,6 +7,9 @@ namespace Spiral\TemporalBridge\Generator;
 use Nette\PhpGenerator\Method;
 use Nette\PhpGenerator\Parameter;
 
+/**
+ * @internal
+ */
 final class Context
 {
     private const INTERFACE = 'Interface';

--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -8,6 +8,9 @@ use Nette\PhpGenerator\PhpNamespace;
 use Spiral\Files\FilesInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * @internal
+ */
 final class Generator
 {
     public function __construct(

--- a/src/Generator/HandlerGenerator.php
+++ b/src/Generator/HandlerGenerator.php
@@ -12,6 +12,9 @@ use Spiral\TemporalBridge\WorkflowManagerInterface;
 use Temporal\Api\Enums\V1\WorkflowIdReusePolicy;
 use Temporal\Exception\Client\WorkflowExecutionAlreadyStartedException;
 
+/**
+ * @internal
+ */
 final class HandlerGenerator implements FileGeneratorInterface
 {
     public function generate(Context $context, PhpNamespace $namespace): PhpCodePrinter
@@ -59,7 +62,7 @@ final class HandlerGenerator implements FileGeneratorInterface
                 <<<'BODY'
 $workflow = $this->manager
     ->createScheduled(
-        %s::class, 
+        %s::class,
         '%s'
     );
 BODY
@@ -83,7 +86,7 @@ BODY
     {
         return <<<'BODY'
 // $workflow->assignId(
-//     'operation-id', 
+//     'operation-id',
 //     WorkflowIdReusePolicy::WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY
 // );
 
@@ -111,17 +114,17 @@ BODY
             <<<'BODY'
 try {
     $run = $workflow->run(%s);
-    
+
     $this->logger->info('Workflow [%s] has been run', [
         'id' => $run->getExecution()->getID()
     ]);
-    
+
     return $run;
 } catch (WorkflowExecutionAlreadyStartedException $e) {
     $this->logger->error('Workflow has been already started.', [
         'name' => $workflow->getWorkflowType()
     ]);
-    
+
     throw $e;
 }
 BODY,

--- a/src/Generator/HandlerInterfaceGenerator.php
+++ b/src/Generator/HandlerInterfaceGenerator.php
@@ -8,6 +8,9 @@ use Nette\PhpGenerator\ClassType;
 use Nette\PhpGenerator\PhpNamespace;
 use Spiral\TemporalBridge\Workflow\RunningWorkflow;
 
+/**
+ * @internal
+ */
 class HandlerInterfaceGenerator implements FileGeneratorInterface
 {
     public function generate(Context $context, PhpNamespace $namespace): PhpCodePrinter

--- a/src/Generator/PhpCodePrinter.php
+++ b/src/Generator/PhpCodePrinter.php
@@ -9,6 +9,9 @@ use Nette\PhpGenerator\PhpNamespace;
 use Nette\PhpGenerator\PsrPrinter;
 use Spiral\Files\FilesInterface;
 
+/**
+ * @internal
+ */
 class PhpCodePrinter
 {
     public function __construct(

--- a/src/Generator/Utils.php
+++ b/src/Generator/Utils.php
@@ -11,6 +11,9 @@ use Temporal\Internal\Workflow\ActivityProxy;
 use Temporal\Workflow\QueryMethod;
 use Temporal\Workflow\SignalMethod;
 
+/**
+ * @internal
+ */
 final class Utils
 {
     public static function addParameters(array $parameters, Method $method): void

--- a/src/Generator/WorkflowGenerator.php
+++ b/src/Generator/WorkflowGenerator.php
@@ -11,6 +11,9 @@ use Temporal\Activity\ActivityOptions;
 use Temporal\Internal\Workflow\ActivityProxy;
 use Temporal\Workflow;
 
+/**
+ * @internal
+ */
 final class WorkflowGenerator implements FileGeneratorInterface
 {
     public function generate(Context $context, PhpNamespace $namespace): PhpCodePrinter

--- a/src/Generator/WorkflowInterfaceGenerator.php
+++ b/src/Generator/WorkflowInterfaceGenerator.php
@@ -11,6 +11,9 @@ use Temporal\Workflow\SignalMethod;
 use Temporal\Workflow\WorkflowInterface;
 use Temporal\Workflow\WorkflowMethod;
 
+/**
+ * @internal
+ */
 final class WorkflowInterfaceGenerator implements FileGeneratorInterface
 {
     public function generate(Context $context, PhpNamespace $namespace): PhpCodePrinter

--- a/src/Workflow/RunningWorkflow.php
+++ b/src/Workflow/RunningWorkflow.php
@@ -4,17 +4,48 @@ declare(strict_types=1);
 
 namespace Spiral\TemporalBridge\Workflow;
 
+use Spiral\TemporalBridge\Exception\WorkflowNotFoundException;
+use Temporal\Client\WorkflowClientInterface;
 use Temporal\Client\WorkflowStubInterface;
+use Temporal\Internal\Client\WorkflowProxy;
 
-class RunningWorkflow
+/**
+ * @template T
+ * @mixin WorkflowStubInterface
+ * @internal
+ */
+final class RunningWorkflow
 {
+    /**
+     * @param non-empty-string $id
+     * @param class-string<T>|null $class
+     */
     public function __construct(
-        private WorkflowStubInterface $workflow
+        private WorkflowClientInterface $client,
+        private WorkflowStubInterface $workflow,
+        private string $id,
+        private ?string $class,
     ) {
     }
 
     public function __call(string $name, array $arguments)
     {
         return call_user_func_array([$this->workflow, $name], $arguments);
+    }
+
+    /**
+     * @param class-string<T>|null $class
+     * @return WorkflowProxy|T
+     * @throws WorkflowNotFoundException
+     */
+    public function getWorkflow(?string $class = null): object
+    {
+        $class ??= $this->class;
+
+        if ($class === null) {
+            throw new WorkflowNotFoundException('Workflow class should be defined.');
+        }
+
+        return $this->client->newRunningWorkflowStub($class, $this->id);
     }
 }

--- a/src/Workflow/Workflow.php
+++ b/src/Workflow/Workflow.php
@@ -12,8 +12,9 @@ use Temporal\Internal\Client\WorkflowProxy;
 
 /**
  * @psalm-template T of object
+ * @internal
  */
-class Workflow
+final class Workflow
 {
     private ?WorkflowSignal $signal = null;
     private ?RetryOptions $retryOptions = null;
@@ -115,11 +116,14 @@ class Workflow
         }
 
         return new RunningWorkflow(
-            $this->client->newUntypedRunningWorkflowStub(
-                $run->getExecution()->getID(),
-                $run->getExecution()->getRunID(),
-                $this->type
-            )
+            client: $this->client,
+            workflow: $this->client->newUntypedRunningWorkflowStub(
+                workflowID: $run->getExecution()->getID(),
+                runID: $run->getExecution()->getRunID(),
+                workflowType: $this->type
+            ),
+            id: $run->getExecution()->getID(),
+            class: $this->class
         );
     }
 
@@ -139,7 +143,6 @@ class Workflow
 
         throw new \BadMethodCallException(\sprintf('Method [%s] doesn\'t exist.', $name));
     }
-
 
     private function createStub(): WorkflowProxy
     {

--- a/src/Workflow/WorkflowManager.php
+++ b/src/Workflow/WorkflowManager.php
@@ -46,10 +46,13 @@ class WorkflowManager implements WorkflowManagerInterface
         $type = $class !== null ? $this->getTypeFromWorkflowClass($class) : null;
 
         return new RunningWorkflow(
+            $this->client,
             $this->client->newUntypedRunningWorkflowStub(
                 workflowID: $id,
                 workflowType: $type
-            )
+            ),
+            $id,
+            $class
         );
     }
 

--- a/src/Workflow/WorkflowSignal.php
+++ b/src/Workflow/WorkflowSignal.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Spiral\TemporalBridge\Workflow;
 
-class WorkflowSignal
+/**
+ * @internal
+ */
+final class WorkflowSignal
 {
     public function __construct(
         private string $name,

--- a/src/WorkflowManagerInterface.php
+++ b/src/WorkflowManagerInterface.php
@@ -12,9 +12,8 @@ use Temporal\Client\WorkflowStubInterface;
 interface WorkflowManagerInterface
 {
     /**
-     * @psalm-template T of object
-     * @param class-string<T> $class
-     * @return RunningWorkflow|T|WorkflowStubInterface
+     * @param class-string $class
+     * @return RunningWorkflow|WorkflowStubInterface
      */
     public function getById(
         string $id,
@@ -22,9 +21,8 @@ interface WorkflowManagerInterface
     ): RunningWorkflow;
 
     /**
-     * @psalm-template T of object
-     * @param class-string<T> $class
-     * @return T|Workflow|WorkflowOptions
+     * @param class-string $class
+     * @return Workflow|WorkflowOptions
      */
     public function create(
         string $class,

--- a/tests/src/Workflow/RunningWorkflowTest.php
+++ b/tests/src/Workflow/RunningWorkflowTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\TemporalBridge\Tests\Workflow;
+
+use Mockery as m;
+use Spiral\TemporalBridge\Exception\WorkflowNotFoundException;
+use Spiral\TemporalBridge\Tests\TestCase;
+use Spiral\TemporalBridge\Workflow\RunningWorkflow;
+use Temporal\Client\WorkflowClientInterface;
+use Temporal\Client\WorkflowStubInterface;
+use Temporal\DataConverter\EncodedValues;
+
+final class RunningWorkflowTest extends TestCase
+{
+    /** @var m\MockInterface|WorkflowClientInterface */
+    private WorkflowClientInterface $client;
+    /** @var m\MockInterface|WorkflowStubInterface */
+    private WorkflowStubInterface $workflowStub;
+    private RunningWorkflow $workflow;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->client = m::mock(WorkflowClientInterface::class);
+        $this->workflowStub = m::mock(WorkflowStubInterface::class);
+
+        $this->workflow = new RunningWorkflow(
+            $this->client,
+            $this->workflowStub,
+            'foo-id',
+            'some-class'
+        );
+    }
+
+    public function testProxyMethods(): void
+    {
+        $this->workflowStub->shouldReceive('query')
+            ->once()
+            ->with('foo', 'bar')
+            ->andReturn($values = EncodedValues::empty());
+
+        $this->assertSame($values, $this->workflow->query('foo', 'bar'));
+    }
+
+    public function testGetsWorkflowObject(): void
+    {
+        $this->client->shouldReceive('newRunningWorkflowStub')
+            ->once()
+            ->with('some-class', 'foo-id')
+            ->andReturn($object = new \stdClass());
+
+        $this->assertSame($object, $this->workflow->getWorkflow());
+    }
+
+    public function testGetsWorkflowObjectWithPassingClass(): void
+    {
+        $this->client->shouldReceive('newRunningWorkflowStub')
+            ->once()
+            ->with('another-class', 'foo-id')
+            ->andReturn($object = new \stdClass());
+
+        $this->assertSame($object, $this->workflow->getWorkflow('another-class'));
+    }
+
+    public function testGetsWorkflowObjectWithoutClass(): void
+    {
+        $this->expectException(WorkflowNotFoundException::class);
+
+        $workflow = new RunningWorkflow(
+            $this->client,
+            $this->workflowStub,
+            'foo-id',
+            null
+        );
+
+        $workflow->getWorkflow();
+    }
+}


### PR DESCRIPTION
```php
// $workflow is untyped without class and you need to pass class into getWorkflow method
$workflow = $workflowManager->getById('some-id');
$workflow->getWorkflow(Some::class);

// $workflow with class
$workflow = $workflowManager->getById('some-id', Some::class);
$workflow->getWorkflow();
```

fixes #40