### PR TITLE
Adds the ability to set the AssignWorker attribute not only directly on Workflow or Activity classes, but also on their parent classes.

### DIFF
--- a/src/Attribute/AssignWorker.php
+++ b/src/Attribute/AssignWorker.php
@@ -10,7 +10,7 @@ use Spiral\Attributes\NamedArgumentConstructor;
 final class AssignWorker
 {
     public function __construct(
-        public readonly string $name
+        public readonly string $name,
     ) {
     }
 }

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -21,7 +21,7 @@ final class Dispatcher implements DispatcherInterface
         private readonly RoadRunnerMode $mode,
         private readonly ReaderInterface $reader,
         private readonly TemporalConfig $config,
-        private readonly Container $container
+        private readonly Container $container,
     ) {
     }
 
@@ -44,7 +44,9 @@ final class Dispatcher implements DispatcherInterface
 
         foreach ($declarations as $type => $declaration) {
             // Worker that listens on a task queue and hosts both workflow and activity implementations.
-            $worker = $registry->get($this->resolveQueueName($declaration));
+            $queueName = $this->resolveQueueName($declaration) ?? $this->config->getDefaultWorker();
+
+            $worker = $registry->get($queueName);
 
             if ($type === WorkflowInterface::class) {
                 // Workflows are stateful. So you need a type to create instances.
@@ -55,7 +57,7 @@ final class Dispatcher implements DispatcherInterface
                 // Workflows are stateful. So you need a type to create instances.
                 $worker->registerActivity(
                     $declaration->getName(),
-                    fn(ReflectionClass $class): object => $this->container->make($class->getName())
+                    fn(ReflectionClass $class): object => $this->container->make($class->getName()),
                 );
             }
         }
@@ -64,14 +66,22 @@ final class Dispatcher implements DispatcherInterface
         $factory->run();
     }
 
-    private function resolveQueueName(\ReflectionClass $declaration): string
+    private function resolveQueueName(\ReflectionClass $declaration): ?string
     {
         $assignWorker = $this->reader->firstClassMetadata($declaration, AssignWorker::class);
 
-        if ($assignWorker === null) {
-            return $this->config->getDefaultWorker();
+        if ($assignWorker !== null) {
+            return $assignWorker->name;
         }
 
-        return $assignWorker->name;
+        $parents = $declaration->getInterfaceNames();
+        foreach ($parents as $parent) {
+            $queueName = $this->resolveQueueName(new \ReflectionClass($parent));
+            if ($queueName !== null) {
+                return $queueName;
+            }
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
This PR introduces a feature that automatically registers activities and workflows with a designated worker when they implement a specific interface. This functionality applies to both Activity and Workflow classes. 

**Here's an example in PHP to illustrate the concept:**

```php
use Spiral\TemporalBridge\Attribute\AssignWorker;
use Temporal\Activity\ActivityInterface;
use Temporal\Workflow\WorkflowInterface;

#[AssignWorker(name: 'some-worker')]
#[ActivityInterface]
interface SomeActivityInterface
{
    // Interface methods for activities
}

#[AssignWorker(name: 'some-worker')]
#[WorkflowInterface]
interface SomeWorkflowInterface
{
    // Interface methods for workflows
}
```

With this implementation, any activity or workflow that implements `SomeActivityInterface` or `SomeWorkflowInterface`, respectively, will be automatically registered with the `some-worker`. 

This enhancement streamlines the process of linking workers to both activities and workflows, ensuring a more efficient and consistent setup with minimal manual configuration.
