### PR TITLE
Implementation of scopes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,10 +37,10 @@
   ],
   "require": {
     "php": "^8.1",
-    "spiral/boot": "^3.0",
+    "spiral/boot": "^3.12",
     "spiral/attributes": "^2.8 || ^3.0",
-    "spiral/tokenizer": "^3.0",
-    "spiral/scaffolder": "^3.0",
+    "spiral/tokenizer": "^3.12",
+    "spiral/scaffolder": "^3.12",
     "spiral/roadrunner-bridge": "^2.0 || ^3.0",
     "temporal/sdk": "^2.7"
   },

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     "temporal/sdk": "^2.7"
   },
   "require-dev": {
-    "spiral/framework": "dev-feature/scopes as 3.12.0",
+    "spiral/framework": "^3.12",
     "spiral/testing": "^2.6",
     "vimeo/psalm": "^5.17"
   },

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     "temporal/sdk": "^2.7"
   },
   "require-dev": {
-    "spiral/framework": "^3.0",
+    "spiral/framework": "dev-feature/scopes as 3.12.0",
     "spiral/testing": "^2.6",
     "vimeo/psalm": "^5.17"
   },

--- a/src/Bootloader/TemporalBridgeBootloader.php
+++ b/src/Bootloader/TemporalBridgeBootloader.php
@@ -82,7 +82,7 @@ class TemporalBridgeBootloader extends Bootloader
         $this->initConfig($env);
 
         $console->addCommand(Commands\InfoCommand::class);
-        $kernel->addDispatcher($this->factory->make(Dispatcher::class));
+        $kernel->addDispatcher(Dispatcher::class);
     }
 
     public function addWorkerOptions(string $worker, WorkerOptions $options): void

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -5,13 +5,16 @@ declare(strict_types=1);
 namespace Spiral\TemporalBridge;
 
 use ReflectionClass;
+use Spiral\Attribute\DispatcherScope;
 use Spiral\Boot\DispatcherInterface;
 use Spiral\Core\Container;
+use Spiral\Framework\Spiral;
 use Spiral\RoadRunnerBridge\RoadRunnerMode;
 use Temporal\Activity\ActivityInterface;
 use Temporal\Worker\WorkerFactoryInterface;
 use Temporal\Workflow\WorkflowInterface;
 
+#[DispatcherScope(Spiral::Temporal)]
 final class Dispatcher implements DispatcherInterface
 {
     public function __construct(

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -80,7 +80,7 @@ final class Dispatcher implements DispatcherInterface
         /** @psalm-suppress InvalidArgument */
         return $this->scope->runScope(
             new Scope('temporal.activity'),
-            static fn(FactoryInterface $factory): object => $factory->make($class->getName()),
+            static fn (FactoryInterface $factory): object => $factory->make($class->getName()),
         );
     }
 }

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -11,26 +11,24 @@ use Spiral\Boot\DispatcherInterface;
 use Spiral\Core\FactoryInterface;
 use Spiral\Core\Scope;
 use Spiral\Core\ScopeInterface;
-use Spiral\Framework\Spiral;
 use Spiral\RoadRunnerBridge\RoadRunnerMode;
 use Temporal\Activity\ActivityInterface;
 use Temporal\Worker\WorkerFactoryInterface;
 use Temporal\Workflow\WorkflowInterface;
 
-#[DispatcherScope(Spiral::Temporal)]
+#[DispatcherScope('temporal')]
 final class Dispatcher implements DispatcherInterface
 {
     public function __construct(
-        private readonly RoadRunnerMode $mode,
         private readonly ContainerInterface $container,
         private readonly DeclarationWorkerResolver $workerResolver,
         private readonly ScopeInterface $scope,
     ) {
     }
 
-    public function canServe(): bool
+    public static function canServe(RoadRunnerMode $mode): bool
     {
-        return \PHP_SAPI === 'cli' && $this->mode === RoadRunnerMode::Temporal;
+        return \PHP_SAPI === 'cli' && $mode === RoadRunnerMode::Temporal;
     }
 
     public function serve(): void
@@ -81,7 +79,7 @@ final class Dispatcher implements DispatcherInterface
     {
         /** @psalm-suppress InvalidArgument */
         return $this->scope->runScope(
-            new Scope(Spiral::TemporalActivity),
+            new Scope('temporal.activity'),
             static fn(FactoryInterface $factory): object => $factory->make($class->getName()),
         );
     }

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -79,7 +79,7 @@ final class Dispatcher implements DispatcherInterface
     {
         /** @psalm-suppress InvalidArgument */
         return $this->scope->runScope(
-            new Scope('temporal.activity'),
+            new Scope('temporal-activity'),
             static fn (FactoryInterface $factory): object => $factory->make($class->getName()),
         );
     }

--- a/tests/app/src/SomeActivityWithScope.php
+++ b/tests/app/src/SomeActivityWithScope.php
@@ -5,10 +5,9 @@ declare(strict_types=1);
 namespace Spiral\TemporalBridge\Tests\App;
 
 use Spiral\Core\Attribute\Scope;
-use Spiral\Framework\Spiral;
 use Spiral\TemporalBridge\Attribute\AssignWorker;
 
-#[Scope(Spiral::TemporalActivity)]
+#[Scope('temporal.activity')]
 #[AssignWorker(taskQueue: 'worker1')]
 class SomeActivityWithScope
 {

--- a/tests/app/src/SomeActivityWithScope.php
+++ b/tests/app/src/SomeActivityWithScope.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\TemporalBridge\Tests\App;
+
+use Spiral\Core\Attribute\Scope;
+use Spiral\Framework\Spiral;
+use Spiral\TemporalBridge\Attribute\AssignWorker;
+
+#[Scope(Spiral::TemporalActivity)]
+#[AssignWorker(taskQueue: 'worker1')]
+class SomeActivityWithScope
+{
+    // Binding ArrayAccess $tasks available only in temporal.activity scope
+    public function __construct(
+        private readonly \ArrayAccess $tasks,
+    ) {
+    }
+}

--- a/tests/app/src/SomeActivityWithScope.php
+++ b/tests/app/src/SomeActivityWithScope.php
@@ -7,11 +7,11 @@ namespace Spiral\TemporalBridge\Tests\App;
 use Spiral\Core\Attribute\Scope;
 use Spiral\TemporalBridge\Attribute\AssignWorker;
 
-#[Scope('temporal.activity')]
+#[Scope('temporal-activity')]
 #[AssignWorker(taskQueue: 'worker1')]
 class SomeActivityWithScope
 {
-    // Binding ArrayAccess $tasks available only in temporal.activity scope
+    // Binding ArrayAccess $tasks available only in `temporal-activity` scope
     public function __construct(
         private readonly \ArrayAccess $tasks,
     ) {

--- a/tests/src/DispatcherTest.php
+++ b/tests/src/DispatcherTest.php
@@ -6,8 +6,6 @@ namespace Spiral\TemporalBridge\Tests;
 
 use Mockery as m;
 use Spiral\Attributes\AttributeReader;
-use Spiral\Framework\Spiral;
-use Spiral\RoadRunnerBridge\RoadRunnerMode;
 use Spiral\TemporalBridge\Config\TemporalConfig;
 use Spiral\TemporalBridge\DeclarationLocatorInterface;
 use Spiral\TemporalBridge\DeclarationWorkerResolver;
@@ -32,7 +30,6 @@ final class DispatcherTest extends TestCase
         parent::setUp();
 
         $this->dispatcher = new Dispatcher(
-            RoadRunnerMode::Temporal,
             $this->getContainer(),
             new DeclarationWorkerResolver(
                 new AttributeReader(),
@@ -107,7 +104,7 @@ final class DispatcherTest extends TestCase
 
     public function testScope(): void
     {
-        $binder = $this->getContainer()->getBinder(Spiral::TemporalActivity);
+        $binder = $this->getContainer()->getBinder('temporal.activity');
         $binder->bind(SomeActivityWithScope::class, SomeActivityWithScope::class);
         $binder->bind(\ArrayAccess::class, $this->createMock(\ArrayAccess::class));
 

--- a/tests/src/DispatcherTest.php
+++ b/tests/src/DispatcherTest.php
@@ -6,6 +6,7 @@ namespace Spiral\TemporalBridge\Tests;
 
 use Mockery as m;
 use Spiral\Attributes\AttributeReader;
+use Spiral\RoadRunnerBridge\RoadRunnerMode;
 use Spiral\TemporalBridge\Config\TemporalConfig;
 use Spiral\TemporalBridge\DeclarationLocatorInterface;
 use Spiral\TemporalBridge\DeclarationWorkerResolver;
@@ -37,6 +38,18 @@ final class DispatcherTest extends TestCase
             ),
             $this->getContainer(),
         );
+    }
+
+    public function testCanServe(): void
+    {
+        $this->assertTrue(Dispatcher::canServe(RoadRunnerMode::Temporal));
+
+        $this->assertFalse(Dispatcher::canServe(RoadRunnerMode::Http));
+        $this->assertFalse(Dispatcher::canServe(RoadRunnerMode::Jobs));
+        $this->assertFalse(Dispatcher::canServe(RoadRunnerMode::Grpc));
+        $this->assertFalse(Dispatcher::canServe(RoadRunnerMode::Tcp));
+        $this->assertFalse(Dispatcher::canServe(RoadRunnerMode::Centrifuge));
+        $this->assertFalse(Dispatcher::canServe(RoadRunnerMode::Unknown));
     }
 
     public function testServeWithoutDeclarations(): void

--- a/tests/src/DispatcherTest.php
+++ b/tests/src/DispatcherTest.php
@@ -112,7 +112,6 @@ final class DispatcherTest extends TestCase
         $binder->bind(\ArrayAccess::class, $this->createMock(\ArrayAccess::class));
 
         $ref = new \ReflectionMethod($this->dispatcher, 'makeActivity');
-        $ref->invoke($this->dispatcher, new \ReflectionClass(SomeActivityWithScope::class));
 
         $this->assertInstanceOf(
             SomeActivityWithScope::class,

--- a/tests/src/DispatcherTest.php
+++ b/tests/src/DispatcherTest.php
@@ -117,7 +117,7 @@ final class DispatcherTest extends TestCase
 
     public function testScope(): void
     {
-        $binder = $this->getContainer()->getBinder('temporal.activity');
+        $binder = $this->getContainer()->getBinder('temporal-activity');
         $binder->bind(SomeActivityWithScope::class, SomeActivityWithScope::class);
         $binder->bind(\ArrayAccess::class, $this->createMock(\ArrayAccess::class));
 


### PR DESCRIPTION
### What was changed

Added a `temporal` scope to the dispatcher. Added opening of the `temporal.activity` scope when creating an activity. Now it is possible to define a scope for an activity and register dependencies in the container so that they are only available within the `temporal.activity` scope.

For example, let's create an activity and specify the **temporal.activity** scope for it:

```php
use Psr\Container\ContainerInterface;
use Spiral\Core\Attribute\Scope;
use Spiral\Framework\Spiral;
use Temporal\Activity\ActivityInterface;
use Temporal\Activity\ActivityMethod;

#[Scope(Spiral::TemporalActivity)] // <------------
#[ActivityInterface]
class PingWebsiteActivity
{
    public function __construct(
        private readonly ContainerInterface $container,
    ) {
        trap($this->container); // container here must be in the temporal.activity scope
    }

    #[ActivityMethod(name: 'ping')]
    public function ping(string $domain): bool
    {
        // ...
    }
}
```

After that, we will define the binding of the activity within the **temporal.activity** scope:

```php
use App\Endpoint\Temporal\Activity\PingWebsiteActivity;
use Spiral\Boot\Bootloader\Bootloader;
use Spiral\Core\BinderInterface;
use Spiral\Framework\Spiral;

final class AppBootloader extends Bootloader
{
    public function __construct(
        private readonly BinderInterface $binder,
    ) {
    }

    public function defineBindings(): array
    {
        $this->binder
            ->getBinder(Spiral::TemporalActivity)
            ->bind(PingWebsiteActivity::class, PingWebsiteActivity::class);

        return [];
    }
}
```

As a result, the activity will receive dependencies that are defined within the **temporal.activity** scope.

<img width="1021" alt="111" src="https://github.com/spiral/temporal-bridge/assets/67324318/e14ab40e-d976-4490-890f-055c5ed0a4f9">

